### PR TITLE
Support February 2020 language update

### DIFF
--- a/addon/globalPlugins/instantTranslate/interface.py
+++ b/addon/globalPlugins/instantTranslate/interface.py
@@ -7,6 +7,7 @@
 #See the file COPYING for more details.
 
 import os.path
+import sys
 import wx
 import gui
 from .langslist import langslist
@@ -85,7 +86,11 @@ class InstantTranslateSettingsPanel(gui.SettingsPanel):
 		keys=list(langslist.keys())
 		auto=lngModule.g("auto")
 		keys.remove(auto)
-		keys.sort(key=strxfrm)
+		if sys.version_info[0] >= 3:
+			keys.sort(key=strxfrm)
+		else:
+			# Python 2: strxfrm does not seem to work correctly, so do not use locale rules for sorting.
+			keys.sort()
 		choices=[]
 		choices.append(auto)
 		choices.extend(keys)

--- a/addon/globalPlugins/instantTranslate/langslist.py
+++ b/addon/globalPlugins/instantTranslate/langslist.py
@@ -26,12 +26,16 @@ needed_codes = {
 	# Translators: The name of a language supported by this add-on.
 	"eo":_("Esperanto"),
 	# Translators: The name of a language supported by this add-on.
+	"haw":_("Hawaiian"),
+	# Translators: The name of a language supported by this add-on.
 	"hmn":_("Hmong"),
 	# Translators: The name of a language supported by this add-on.
 	"ht":_("Creole Haiti"),
 	# Translators: The name of a language supported by this add-on.
 	"jv":_("Javanese"),
 	# Translators: The name of a language supported by this add-on.
+	# Translators: The name of a language supported by this add-on.
+	"ku":_("Kurdish"),
 	"la":_("Latin"),
 	# Translators: The name of a language supported by this add-on.
 	"mg":_("Malagasy"),
@@ -39,6 +43,8 @@ needed_codes = {
 	"my":_("Myanmar (Burmese)"),
 	# Translators: The name of a language supported by this add-on.
 	"ny":_("Chichewa"),
+	# Translators: The name of a language supported by this add-on.
+	"sd":_("Sindhi"),
 	# Translators: The name of a language supported by this add-on.
 	"sm":_("Samoan"),
 	# Translators: The name of a language supported by this add-on.
@@ -126,12 +132,14 @@ langcodes = [
 	"nl",
 	"no",
 	"ny",
+	"or",
 	"pa",
 	"pl",
 	"ps",
 	"pt",
 	"ro",
 	"ru",
+	"rw",
 	"sd",
 	"si",
 	"sk",
@@ -149,8 +157,11 @@ langcodes = [
 	"te",
 	"tg",
 	"th",
+	"tk",
 	"tl",
 	"tr",
+	"tt",
+	"ug",
 	"uk",
 	"ur",
 	"uz",


### PR DESCRIPTION
Google Translate added some new supported languages in Feb 2020. This PR contains the following:
* Added new language support following Google Translate february 2020 update (Kinyarwanda, Odia, Tatar, Turkmen, Uyghur).
* Fixed some missing language names on Windows 7 (only ISO language codes were seen in the language list).
* Remove locale-aware sorting for NVDA version up to 2019.2.
NB: locale-aware sorting was introduced in commit c6e0015. However, this broke parameter panel with NVDA 2019.2 or below. This bug (encoding issue) may be fixed. But I have not succeeded in making locale-aware sorting (strxfrm or strcoll) work correctly with Python 2. So I have just removed it for Python 2.
